### PR TITLE
Issue: fix SignUpPage.test.tsx - Migrate from custom form to Clerk patterns

### DIFF
--- a/src/app/(auth)/__tests__/SignUpPage.test.tsx
+++ b/src/app/(auth)/__tests__/SignUpPage.test.tsx
@@ -1,315 +1,37 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { useRouter } from 'next/navigation';
 import SignUpPage from '../signup/page';
+import { mockNavigation, testAuthPageBehavior, mockUseAuth } from './auth-test-utils';
+import { render } from '@testing-library/react';
+import { authStates } from './test-helpers';
 
-// Mock next/navigation
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: jest.fn(),
+  SignUp: jest.fn(() => <div data-testid="clerk-signup-component">Clerk SignUp Component</div>),
 }));
 
-// Mock fetch function
-global.fetch = jest.fn();
+mockNavigation();
 
 describe('SignUpPage Component', () => {
-  const mockRouter = {
-    push: jest.fn(),
-  };
-
-  // Helper function to fill out the registration form
-  const fillRegistrationForm = async () => {
-    await userEvent.type(screen.getByLabelText(/First Name/i), 'John');
-    await userEvent.type(screen.getByLabelText(/Last Name/i), 'Doe');
-    await userEvent.type(screen.getByLabelText(/Username/i), 'johndoe');
-    await userEvent.type(
-      screen.getByLabelText(/Email/i),
-      'john.doe@example.com'
-    );
-    await userEvent.type(screen.getByLabelText(/^Password/i), 'Password123!');
-    await userEvent.type(
-      screen.getByLabelText(/Confirm Password/i),
-      'Password123!'
-    );
-    await userEvent.click(screen.getByLabelText(/I agree to the/i));
-  };
-
-  // Helper function to submit the form
-  const submitForm = async () => {
-    await userEvent.click(
-      screen.getByRole('button', { name: /Create Account/i })
-    );
-  };
-
-  // Helper function to setup API mock with custom response
-  const setupApiMock = (responseData: any) => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue(responseData),
-    });
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
-    (useRouter as jest.Mock).mockReturnValue(mockRouter);
-    setupApiMock({
-      success: true,
-      message: 'User registered successfully',
-      user: { id: '123', email: 'test@example.com' },
-    });
   });
 
-  it('renders the signup form correctly', () => {
+  testAuthPageBehavior({
+    component: SignUpPage,
+    expectedTestId: 'clerk-signup-component',
+    signUpText: 'Create your account',
+  });
+
+  it('should configure SignUp component with correct redirectUrl', () => {
+    mockUseAuth(authStates.notSignedIn);
+    const { SignUp } = require('@clerk/nextjs');
+
     render(<SignUpPage />);
 
-    expect(screen.getByText('Create your account')).toBeInTheDocument();
-    expect(screen.getByLabelText(/First Name/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Last Name/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Username/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/^Password/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Confirm Password/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/I agree to the/i)).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/Subscribe to our newsletter/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /Create Account/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Already have an account/i)).toBeInTheDocument();
-  });
-
-  it('submits the form with valid data', async () => {
-    render(<SignUpPage />);
-
-    await fillRegistrationForm();
-    await submitForm();
-
-    await waitFor(() => {
-      // Use expect.objectContaining to handle potential differences in property order
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/api/auth/register',
-        expect.objectContaining({
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
-      );
-
-      // Verify the body contains all expected fields regardless of order
-      const actualCall = (global.fetch as jest.Mock).mock.calls[0][1];
-      const parsedBody = JSON.parse(actualCall.body);
-
-      expect(parsedBody).toEqual({
-        firstName: 'John',
-        lastName: 'Doe',
-        username: 'johndoe',
-        email: 'john.doe@example.com',
-        password: 'Password123!',
-        confirmPassword: 'Password123!',
-        agreeToTerms: true,
-        subscribeToNewsletter: false,
-      });
-
-      expect(mockRouter.push).toHaveBeenCalledWith(
-        '/verify-email?email=john.doe%40example.com'
-      );
-    });
-  });
-
-  // Updated to be more robust in CI environments
-  it('shows validation errors for invalid form data', async () => {
-    render(<SignUpPage />);
-
-    // Submit the form without filling any fields
-    await userEvent.click(
-      screen.getByRole('button', { name: /Create Account/i })
-    );
-
-    await waitFor(() => {
-      // Check for validation errors using a more robust approach
-      // Look for any text containing validation-related terms
-      const errorTexts = [/required/i, /invalid/i, /must be/i, /cannot/i];
-
-      // Find any elements containing these error messages
-      const pageContent = document.body.textContent || '';
-
-      // At least one of these error patterns should appear in the page content
-      const hasValidationError = errorTexts.some(pattern =>
-        pattern.test(pageContent)
-      );
-      expect(hasValidationError).toBe(true);
-
-      // The form should remain interactive (not in loading state)
-      const submitButton = screen.getByRole('button', {
-        name: /Create Account/i,
-      });
-      expect(submitButton).toBeEnabled();
-    });
-  });
-
-  // Updated test to be more robust in CI environments
-  it('handles server errors', async () => {
-    // Mock fetch to return an error
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      json: jest.fn().mockResolvedValue({
-        success: false,
-        message: 'Email already exists',
-        errors: [{ field: 'email', message: 'Email already exists' }],
+    expect(SignUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUrl: '/profile-setup',
       }),
-    });
-
-    render(<SignUpPage />);
-
-    await fillRegistrationForm();
-    await submitForm();
-
-    // Essential behavior to test:
-    // 1. API request is made (fetch is called)
-    // 2. Router is not called (user is not redirected)
-    // 3. Form remains enabled (not submitting state anymore)
-    await waitFor(() => {
-      // Check the API call was made with the right data
-      expect(global.fetch).toHaveBeenCalledWith(
-        '/api/auth/register',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
-          }),
-        })
-      );
-
-      // User should not be redirected after error
-      expect(mockRouter.push).not.toHaveBeenCalled();
-
-      // Verify the form state after server error
-      // Since errors might be displayed in various ways, we'll check the form's state
-      // in a more reliable way by inspecting component properties rather than DOM elements
-
-      // 1. The submit button should be enabled again (not in loading state)
-      const submitButton = screen.getByRole('button', {
-        name: /Create Account/i,
-      });
-      expect(submitButton).toBeEnabled();
-      expect(submitButton).not.toHaveAttribute('disabled');
-      expect(submitButton).not.toHaveTextContent(/Creating account/i);
-    });
-  });
-
-  describe('Status code error handling', () => {
-    // Helper function to test error status codes
-    const testErrorStatusCode = async (status: number, responseData: any) => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-        status,
-        json: jest.fn().mockResolvedValue(responseData),
-      });
-
-      render(<SignUpPage />);
-      await fillRegistrationForm();
-      await submitForm();
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
-        expect(mockRouter.push).not.toHaveBeenCalled();
-        const submitButton = screen.getByRole('button', {
-          name: /Create Account/i,
-        });
-        expect(submitButton).toBeEnabled();
-      });
-    };
-
-    it('handles 400 status code with validation errors', async () => {
-      await testErrorStatusCode(400, {
-        success: false,
-        message: 'Validation failed',
-        errors: [{ field: 'email', message: 'Invalid email format' }],
-      });
-    });
-
-    it('handles 409 status code with conflict errors', async () => {
-      await testErrorStatusCode(409, {
-        success: false,
-        message: 'User already exists',
-        errors: [{ field: 'email', message: 'Email already exists' }],
-      });
-    });
-
-    it('handles other error status codes differently', async () => {
-      await testErrorStatusCode(500, {
-        success: false,
-        message: 'Internal server error',
-      });
-    });
-  });
-
-  describe('Email verification bypass', () => {
-    it('redirects to sign-in page when email bypass is enabled', async () => {
-      // Mock API response for bypassed email verification
-      setupApiMock({
-        success: true,
-        message: 'User registered successfully',
-        user: { id: '123', email: 'test@example.com' },
-        emailBypass: true,
-      });
-
-      render(<SignUpPage />);
-
-      await fillRegistrationForm();
-      await submitForm();
-
-      await waitFor(() => {
-        // Should redirect to sign-in with profile setup next step when email is bypassed
-        expect(mockRouter.push).toHaveBeenCalledWith(
-          '/signin?next=/profile-setup'
-        );
-      });
-    });
-
-    it('redirects to email verification page when email bypass is disabled', async () => {
-      // Mock API response for normal email verification flow
-      setupApiMock({
-        success: true,
-        message: 'User registered successfully',
-        user: { id: '123', email: 'test@example.com' },
-        emailBypass: false,
-      });
-
-      render(<SignUpPage />);
-
-      await fillRegistrationForm();
-      await submitForm();
-
-      await waitFor(() => {
-        // Should redirect to email verification page when bypass is disabled
-        expect(mockRouter.push).toHaveBeenCalledWith(
-          '/verify-email?email=john.doe%40example.com'
-        );
-      });
-    });
-
-    it('defaults to email verification flow when emailBypass is not provided', async () => {
-      // Mock API response without emailBypass property (backward compatibility)
-      setupApiMock({
-        success: true,
-        message: 'User registered successfully',
-        user: { id: '123', email: 'test@example.com' },
-      });
-
-      render(<SignUpPage />);
-
-      await fillRegistrationForm();
-      await submitForm();
-
-      await waitFor(() => {
-        // Should default to email verification page for backward compatibility
-        expect(mockRouter.push).toHaveBeenCalledWith(
-          '/verify-email?email=john.doe%40example.com'
-        );
-      });
-    });
+      expect.any(Object)
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Fixed failing SignUpPage test by migrating from legacy custom signup form tests to Clerk-compatible patterns
- Replaced custom form field tests with Clerk SignUp component integration tests  
- Used existing testAuthPageBehavior helper for consistent authentication testing
- Followed established pattern from ClerkSignUpPage.test.tsx

## Changes Made

- **Test Migration**: Replaced 315+ lines of custom form testing with 37 lines of Clerk-focused tests
- **Pattern Consistency**: Used same authentication state mocking and component verification as other Clerk tests
- **Clerk Integration**: Tests now verify proper Clerk SignUp component configuration and redirectUrl
- **Authentication States**: Covers loading, authenticated, and unauthenticated states

## Test Results

- All 5 SignUpPage tests now pass
- ESLint checks pass with no errors
- Tests follow established Clerk migration patterns from MIGRATION_STEPS.md

## Pattern Identified

The issue was that the test was expecting custom form fields (First Name, Last Name, Username, etc.) but the actual component uses Clerks SignUp component which renders its own form. This is part of the NextAuth to Clerk migration where custom forms were replaced with Clerks pre-built components.

CLOSES: N/A (fixing failing test suite)

🤖 Generated with [Claude Code](https://claude.ai/code)